### PR TITLE
Implement link processing for Markdown and HTTP/HTTPS links

### DIFF
--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -51,6 +51,10 @@ export const execute = async (message: Message, client: Client) => {
         text += `（${attachmentTypes.join("と")}が添付されました）`;
       }
     }
+    // まずMarkdown形式のリンクは、リンク部分だけ消して名前だけ残すよ！
+    text = text.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g, "$1");
+    // それ以外のhttp/httpsリンクは「リンク省略」にしとくね！
+    text = text.replace(/https?:\/\/\S+/g, "リンク省略");
     const headers = {
       Authorization: `ApiKey ${process.env.VOICEVOX_API_KEY}`,
     };


### PR DESCRIPTION
Add functionality to handle Markdown links and HTTP/HTTPS links appropriately, ensuring that only the link text remains for Markdown links and replacing other links with a placeholder.