### PR TITLE
Update Docker image references in workflow

### DIFF
--- a/.github/workflows/docker-tag.yaml
+++ b/.github/workflows/docker-tag.yaml
@@ -32,7 +32,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: registry.uniproject.jp/unibot/unibot
+          images: registry.uniproject.jp/infra/unibot
           tags: |
             type=raw,value=latest
             type=semver,pattern={{version}}
@@ -45,5 +45,5 @@ jobs:
           context: .
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=registry.uniproject.jp/unibot/unibot:buildcache
-          cache-to: type=registry,ref=registry.uniproject.jp/unibot/unibot:buildcache,mode=max
+          cache-from: type=registry,ref=registry.uniproject.jp/infra/unibot:buildcache
+          cache-to: type=registry,ref=registry.uniproject.jp/infra/unibot:buildcache,mode=max


### PR DESCRIPTION
This pull request updates the Docker image registry path in the GitHub Actions workflow file to reflect a new organizational structure. The changes ensure that Docker images and build caches are pushed to the correct location under the `infra` namespace, replacing the previous `unibot` namespace.

Docker image registry updates:

* Updated the Docker image path in the `docker/metadata-action` step from `registry.uniproject.jp/unibot/unibot` to `registry.uniproject.jp/infra/unibot` in `.github/workflows/docker-tag.yaml`.
* Changed the build cache registry references in the Docker build step from `registry.uniproject.jp/unibot/unibot:buildcache` to `registry.uniproject.jp/infra/unibot:buildcache` in `.github/workflows/docker-tag.yaml`.