### PR TITLE
[v9] Projectsにあるロールパネル機能の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work.sum
 # Scripts included sensitive information
 scripts/build.sh
 docker-compose.prod.yaml
+docker-compose.yaml

--- a/src/internal/bot/command/commands.go
+++ b/src/internal/bot/command/commands.go
@@ -3,6 +3,7 @@ package command
 import (
 	"unibot/internal/bot/command/admin"
 	"unibot/internal/bot/command/general"
+	"unibot/internal/bot/command/server_management"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -12,4 +13,5 @@ var Commands = []*discordgo.ApplicationCommand{
 	general.LoadAboutCommandContext(),
 	general.LoadTtsCommandContext(),
 	admin.LoadMaintenanceCommandContext(),
+	server_management.LoadRolepanelCommandContext(),
 }

--- a/src/internal/bot/command/registry.go
+++ b/src/internal/bot/command/registry.go
@@ -4,6 +4,7 @@ import (
 	"unibot/internal"
 	"unibot/internal/bot/command/admin"
 	"unibot/internal/bot/command/general"
+	"unibot/internal/bot/command/server_management"
 
 	"github.com/bwmarrin/discordgo"
 )
@@ -13,4 +14,5 @@ var Handlers = map[string]func(*internal.BotContext, *discordgo.Session, *discor
 	"about":       general.About,
 	"maintenance": admin.Maintenance,
 	"tts":         general.Tts,
+	"rolepanel":   server_management.Rolepanel,
 }

--- a/src/internal/bot/command/server_management/rolepanel.go
+++ b/src/internal/bot/command/server_management/rolepanel.go
@@ -1,0 +1,65 @@
+package server_management
+
+import (
+	"time"
+	"unibot/internal"
+	"unibot/internal/bot/command/server_management/rolepanel"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func LoadRolepanelCommandContext() *discordgo.ApplicationCommand {
+	return &discordgo.ApplicationCommand{
+		Name:                     "rolepanel",
+		Description:              "ロールパネルを管理します",
+		DefaultMemberPermissions: ptrInt64(discordgo.PermissionManageRoles),
+		Options: []*discordgo.ApplicationCommandOption{
+			rolepanel.LoadCreateCommandContext(),
+			rolepanel.LoadDeleteCommandContext(),
+			rolepanel.LoadAddCommandContext(),
+			rolepanel.LoadRemoveCommandContext(),
+			rolepanel.LoadListCommandContext(),
+		},
+	}
+}
+
+func ptrInt64(i int64) *int64 {
+	return &i
+}
+
+var rolepanelHandler = map[string]func(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate){
+	"create": rolepanel.Create,
+	"delete": rolepanel.Delete,
+	"add":    rolepanel.Add,
+	"remove": rolepanel.Remove,
+	"list":   rolepanel.List,
+}
+
+func Rolepanel(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	subCommand := i.ApplicationCommandData().Options[0]
+
+	if handler, exists := rolepanelHandler[subCommand.Name]; exists {
+		handler(ctx, s, i)
+		return
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "エラー",
+					Description: "不明なサブコマンドです。",
+					Color:       config.Colors.Error,
+					Footer: &discordgo.MessageEmbedFooter{
+						Text:    "Requested by " + i.Member.DisplayName(),
+						IconURL: i.Member.AvatarURL(""),
+					},
+					Timestamp: time.Now().Format(time.RFC3339),
+				},
+			},
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/src/internal/bot/command/server_management/rolepanel/add.go
+++ b/src/internal/bot/command/server_management/rolepanel/add.go
@@ -1,0 +1,154 @@
+package rolepanel
+
+import (
+	"fmt"
+	"time"
+	"unibot/internal"
+	"unibot/internal/repository"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func LoadAddCommandContext() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Name:        "add",
+		Description: "ロールパネルにロールを追加します",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        "role",
+				Description: "追加するロール",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "label",
+				Description: "セレクトメニューに表示するラベル",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "description",
+				Description: "ロールの説明",
+				Required:    false,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "emoji",
+				Description: "絵文字 (例: 🎮)",
+				Required:    false,
+			},
+		},
+	}
+}
+
+func Add(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	options := i.ApplicationCommandData().Options[0].Options
+
+	var roleID, label, description, emoji string
+	for _, opt := range options {
+		switch opt.Name {
+		case "role":
+			roleID = opt.RoleValue(s, i.GuildID).ID
+		case "label":
+			label = opt.StringValue()
+		case "description":
+			description = opt.StringValue()
+		case "emoji":
+			emoji = opt.StringValue()
+		}
+	}
+
+	repo := repository.NewRolePanelRepository(ctx.DB)
+
+	// このギルドのパネル一覧を取得
+	panels, err := repo.ListByGuild(i.GuildID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルの取得中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	if len(panels) == 0 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このサーバーにはロールパネルがありません。\n先に `/rolepanel create` でパネルを作成してください。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// パネル選択用セレクトメニューを作成
+	var selectOptions []discordgo.SelectMenuOption
+	for _, panel := range panels {
+		selectOptions = append(selectOptions, discordgo.SelectMenuOption{
+			Label:       panel.Title,
+			Value:       panel.MessageID,
+			Description: fmt.Sprintf("%d個のロール", len(panel.Options)),
+		})
+	}
+
+	// CustomIDにロール情報をエンコード (roleID|label|description|emoji)
+	customID := fmt.Sprintf("rolepanel_add_%s|%s|%s|%s", roleID, label, description, emoji)
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "パネルを選択",
+					Description: fmt.Sprintf("ロール <@&%s> を追加するパネルを選択してください。", roleID),
+					Color:       config.Colors.Primary,
+					Footer: &discordgo.MessageEmbedFooter{
+						Text:    "Requested by " + i.Member.DisplayName(),
+						IconURL: i.Member.AvatarURL(""),
+					},
+					Timestamp: time.Now().Format(time.RFC3339),
+				},
+			},
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.SelectMenu{
+							CustomID:    customID,
+							Placeholder: "パネルを選択...",
+							Options:     selectOptions,
+						},
+					},
+				},
+			},
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/src/internal/bot/command/server_management/rolepanel/add.go
+++ b/src/internal/bot/command/server_management/rolepanel/add.go
@@ -26,18 +26,21 @@ func LoadAddCommandContext() *discordgo.ApplicationCommandOption {
 				Name:        "label",
 				Description: "セレクトメニューに表示するラベル",
 				Required:    true,
+				MaxLength:   100,
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "description",
 				Description: "ロールの説明",
 				Required:    false,
+				MaxLength:   100,
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "emoji",
 				Description: "絵文字 (例: 🎮)",
 				Required:    false,
+				MaxLength:   100,
 			},
 		},
 	}

--- a/src/internal/bot/command/server_management/rolepanel/add.go
+++ b/src/internal/bot/command/server_management/rolepanel/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 	"unibot/internal"
+	"unibot/internal/bot/messageComponent"
 	"unibot/internal/repository"
 
 	"github.com/bwmarrin/discordgo"
@@ -122,8 +123,37 @@ func Add(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.Interactio
 		})
 	}
 
-	// CustomIDにロール情報をエンコード (roleID|label|description|emoji)
-	customID := fmt.Sprintf("rolepanel_add_%s|%s|%s|%s", roleID, label, description, emoji)
+	token, err := messageComponent.SaveRolePanelPendingAdd(messageComponent.RolePanelPendingAdd{
+		UserID:      i.Member.User.ID,
+		GuildID:     i.GuildID,
+		RoleID:      roleID,
+		Label:       label,
+		Description: description,
+		Emoji:       emoji,
+	})
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "ロール追加情報の準備中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	customID := "rolepanel_add_" + token
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,

--- a/src/internal/bot/command/server_management/rolepanel/create.go
+++ b/src/internal/bot/command/server_management/rolepanel/create.go
@@ -1,0 +1,143 @@
+package rolepanel
+
+import (
+	"fmt"
+	"time"
+	"unibot/internal"
+	"unibot/internal/model"
+	"unibot/internal/repository"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func LoadCreateCommandContext() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Name:        "create",
+		Description: "ロールパネルを作成します",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "title",
+				Description: "パネルのタイトル",
+				Required:    true,
+			},
+			{
+				Type:        discordgo.ApplicationCommandOptionString,
+				Name:        "description",
+				Description: "パネルの説明",
+				Required:    false,
+			},
+		},
+	}
+}
+
+func Create(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	options := i.ApplicationCommandData().Options[0].Options
+
+	var title, description string
+	for _, opt := range options {
+		switch opt.Name {
+		case "title":
+			title = opt.StringValue()
+		case "description":
+			description = opt.StringValue()
+		}
+	}
+
+	// パネルメッセージを送信
+	panelEmbed := &discordgo.MessageEmbed{
+		Title:       title,
+		Description: description,
+		Color:       config.Colors.Primary,
+		Footer: &discordgo.MessageEmbedFooter{
+			Text: "ロールを選択してください",
+		},
+		Timestamp: time.Now().Format(time.RFC3339),
+	}
+
+	msg, err := s.ChannelMessageSendEmbed(i.ChannelID, panelEmbed)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルの作成中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// データベースに保存
+	repo := repository.NewRolePanelRepository(ctx.DB)
+	panel := &model.RolePanel{
+		GuildID:     i.GuildID,
+		ChannelID:   i.ChannelID,
+		MessageID:   msg.ID,
+		Title:       title,
+		Description: description,
+	}
+
+	err = repo.Create(panel)
+	if err != nil {
+		// メッセージを削除
+		_ = s.ChannelMessageDelete(i.ChannelID, msg.ID)
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルの保存中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "ロールパネルを作成しました",
+					Description: fmt.Sprintf("メッセージID: `%s`\n\n`/rolepanel add` コマンドでロールを追加してください。", msg.ID),
+					Color:       config.Colors.Success,
+					Fields: []*discordgo.MessageEmbedField{
+						{
+							Name:   "タイトル",
+							Value:  title,
+							Inline: true,
+						},
+					},
+					Footer: &discordgo.MessageEmbedFooter{
+						Text:    "Requested by " + i.Member.DisplayName(),
+						IconURL: i.Member.AvatarURL(""),
+					},
+					Timestamp: time.Now().Format(time.RFC3339),
+				},
+			},
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/src/internal/bot/command/server_management/rolepanel/create.go
+++ b/src/internal/bot/command/server_management/rolepanel/create.go
@@ -21,12 +21,14 @@ func LoadCreateCommandContext() *discordgo.ApplicationCommandOption {
 				Name:        "title",
 				Description: "パネルのタイトル",
 				Required:    true,
+				MaxLength:   256,
 			},
 			{
 				Type:        discordgo.ApplicationCommandOptionString,
 				Name:        "description",
 				Description: "パネルの説明",
 				Required:    false,
+				MaxLength:   4096,
 			},
 		},
 	}

--- a/src/internal/bot/command/server_management/rolepanel/delete.go
+++ b/src/internal/bot/command/server_management/rolepanel/delete.go
@@ -1,0 +1,109 @@
+package rolepanel
+
+import (
+	"fmt"
+	"time"
+	"unibot/internal"
+	"unibot/internal/repository"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func LoadDeleteCommandContext() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Name:        "delete",
+		Description: "ロールパネルを削除します",
+	}
+}
+
+func Delete(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	repo := repository.NewRolePanelRepository(ctx.DB)
+
+	// このギルドのパネル一覧を取得
+	panels, err := repo.ListByGuild(i.GuildID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルの取得中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	if len(panels) == 0 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このサーバーにはロールパネルがありません。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// パネル選択用セレクトメニューを作成
+	var selectOptions []discordgo.SelectMenuOption
+	for _, panel := range panels {
+		selectOptions = append(selectOptions, discordgo.SelectMenuOption{
+			Label:       panel.Title,
+			Value:       panel.MessageID,
+			Description: fmt.Sprintf("%d個のロール", len(panel.Options)),
+		})
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "パネルを選択",
+					Description: "削除するパネルを選択してください。",
+					Color:       config.Colors.Primary,
+					Footer: &discordgo.MessageEmbedFooter{
+						Text:    "Requested by " + i.Member.DisplayName(),
+						IconURL: i.Member.AvatarURL(""),
+					},
+					Timestamp: time.Now().Format(time.RFC3339),
+				},
+			},
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.SelectMenu{
+							CustomID:    "rolepanel_delete",
+							Placeholder: "パネルを選択...",
+							Options:     selectOptions,
+						},
+					},
+				},
+			},
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/src/internal/bot/command/server_management/rolepanel/list.go
+++ b/src/internal/bot/command/server_management/rolepanel/list.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"time"
 	"unibot/internal"
+	"unibot/internal/bot/messageComponent"
+	"unibot/internal/model"
 	"unibot/internal/repository"
 
 	"github.com/bwmarrin/discordgo"
@@ -70,8 +72,21 @@ func List(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.Interacti
 	var fields []*discordgo.MessageEmbedField
 	for _, panel := range panels {
 		var roles []string
+		roleIDsByKey, err := loadPanelRoleIDs(s, panel)
+		if err != nil {
+			fields = append(fields, &discordgo.MessageEmbedField{
+				Name:   fmt.Sprintf("%s (ID: %s)", panel.Title, panel.MessageID),
+				Value:  fmt.Sprintf("チャンネル: <#%s>\nロール: 取得失敗", panel.ChannelID),
+				Inline: false,
+			})
+			continue
+		}
+
 		for _, opt := range panel.Options {
-			roles = append(roles, fmt.Sprintf("<@&%s>", opt.RoleID))
+			roleID, ok := roleIDsByKey[opt.OptionKey]
+			if ok {
+				roles = append(roles, fmt.Sprintf("<@&%s>", roleID))
+			}
 		}
 
 		roleList := "なし"
@@ -105,4 +120,12 @@ func List(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.Interacti
 			Flags: discordgo.MessageFlagsEphemeral,
 		},
 	})
+}
+
+func loadPanelRoleIDs(s *discordgo.Session, panel *model.RolePanel) (map[string]string, error) {
+	message, err := s.ChannelMessage(panel.ChannelID, panel.MessageID)
+	if err != nil {
+		return nil, err
+	}
+	return messageComponent.RolePanelRoleIDsByOptionKey(message)
 }

--- a/src/internal/bot/command/server_management/rolepanel/list.go
+++ b/src/internal/bot/command/server_management/rolepanel/list.go
@@ -1,0 +1,108 @@
+package rolepanel
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unibot/internal"
+	"unibot/internal/repository"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func LoadListCommandContext() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Name:        "list",
+		Description: "このサーバーのロールパネル一覧を表示します",
+	}
+}
+
+func List(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	repo := repository.NewRolePanelRepository(ctx.DB)
+
+	panels, err := repo.ListByGuild(i.GuildID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルの取得中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	if len(panels) == 0 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "ロールパネル一覧",
+						Description: "このサーバーにはロールパネルがありません。\n\n`/rolepanel create` でパネルを作成してください。",
+						Color:       config.Colors.Primary,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	var fields []*discordgo.MessageEmbedField
+	for _, panel := range panels {
+		var roles []string
+		for _, opt := range panel.Options {
+			roles = append(roles, fmt.Sprintf("<@&%s>", opt.RoleID))
+		}
+
+		roleList := "なし"
+		if len(roles) > 0 {
+			roleList = strings.Join(roles, ", ")
+		}
+
+		fields = append(fields, &discordgo.MessageEmbedField{
+			Name:   fmt.Sprintf("%s (ID: %s)", panel.Title, panel.MessageID),
+			Value:  fmt.Sprintf("チャンネル: <#%s>\nロール: %s", panel.ChannelID, roleList),
+			Inline: false,
+		})
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "ロールパネル一覧",
+					Description: fmt.Sprintf("このサーバーには %d 個のロールパネルがあります。", len(panels)),
+					Color:       config.Colors.Primary,
+					Fields:      fields,
+					Footer: &discordgo.MessageEmbedFooter{
+						Text:    "Requested by " + i.Member.DisplayName(),
+						IconURL: i.Member.AvatarURL(""),
+					},
+					Timestamp: time.Now().Format(time.RFC3339),
+				},
+			},
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/src/internal/bot/command/server_management/rolepanel/remove.go
+++ b/src/internal/bot/command/server_management/rolepanel/remove.go
@@ -1,0 +1,151 @@
+package rolepanel
+
+import (
+	"fmt"
+	"time"
+	"unibot/internal"
+	"unibot/internal/repository"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func LoadRemoveCommandContext() *discordgo.ApplicationCommandOption {
+	return &discordgo.ApplicationCommandOption{
+		Type:        discordgo.ApplicationCommandOptionSubCommand,
+		Name:        "remove",
+		Description: "ロールパネルからロールを削除します",
+		Options: []*discordgo.ApplicationCommandOption{
+			{
+				Type:        discordgo.ApplicationCommandOptionRole,
+				Name:        "role",
+				Description: "削除するロール",
+				Required:    true,
+			},
+		},
+	}
+}
+
+func Remove(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	options := i.ApplicationCommandData().Options[0].Options
+
+	var roleID string
+	for _, opt := range options {
+		if opt.Name == "role" {
+			roleID = opt.RoleValue(s, i.GuildID).ID
+		}
+	}
+
+	repo := repository.NewRolePanelRepository(ctx.DB)
+
+	// このギルドのパネル一覧を取得
+	panels, err := repo.ListByGuild(i.GuildID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルの取得中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// このロールを含むパネルをフィルタ
+	var matchingPanels []*struct {
+		Title     string
+		MessageID string
+		RoleCount int
+	}
+	for _, panel := range panels {
+		for _, opt := range panel.Options {
+			if opt.RoleID == roleID {
+				matchingPanels = append(matchingPanels, &struct {
+					Title     string
+					MessageID string
+					RoleCount int
+				}{
+					Title:     panel.Title,
+					MessageID: panel.MessageID,
+					RoleCount: len(panel.Options),
+				})
+				break
+			}
+		}
+	}
+
+	if len(matchingPanels) == 0 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: fmt.Sprintf("ロール <@&%s> を含むパネルが見つかりません。", roleID),
+						Color:       config.Colors.Error,
+						Footer: &discordgo.MessageEmbedFooter{
+							Text:    "Requested by " + i.Member.DisplayName(),
+							IconURL: i.Member.AvatarURL(""),
+						},
+						Timestamp: time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// パネル選択用セレクトメニューを作成
+	var selectOptions []discordgo.SelectMenuOption
+	for _, panel := range matchingPanels {
+		selectOptions = append(selectOptions, discordgo.SelectMenuOption{
+			Label:       panel.Title,
+			Value:       panel.MessageID,
+			Description: fmt.Sprintf("%d個のロール", panel.RoleCount),
+		})
+	}
+
+	customID := fmt.Sprintf("rolepanel_remove_%s", roleID)
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "パネルを選択",
+					Description: fmt.Sprintf("ロール <@&%s> を削除するパネルを選択してください。", roleID),
+					Color:       config.Colors.Primary,
+					Footer: &discordgo.MessageEmbedFooter{
+						Text:    "Requested by " + i.Member.DisplayName(),
+						IconURL: i.Member.AvatarURL(""),
+					},
+					Timestamp: time.Now().Format(time.RFC3339),
+				},
+			},
+			Components: []discordgo.MessageComponent{
+				discordgo.ActionsRow{
+					Components: []discordgo.MessageComponent{
+						discordgo.SelectMenu{
+							CustomID:    customID,
+							Placeholder: "パネルを選択...",
+							Options:     selectOptions,
+						},
+					},
+				},
+			},
+			Flags: discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/src/internal/bot/command/server_management/rolepanel/remove.go
+++ b/src/internal/bot/command/server_management/rolepanel/remove.go
@@ -68,31 +68,44 @@ func Remove(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.Interac
 		MessageID string
 		RoleCount int
 	}
+	hadReadError := false
 	for _, panel := range panels {
-		for _, opt := range panel.Options {
-			if opt.RoleID == roleID {
-				matchingPanels = append(matchingPanels, &struct {
-					Title     string
-					MessageID string
-					RoleCount int
-				}{
-					Title:     panel.Title,
-					MessageID: panel.MessageID,
-					RoleCount: len(panel.Options),
-				})
-				break
+		roleIDsByKey, err := loadPanelRoleIDs(s, panel)
+		if err != nil {
+			hadReadError = true
+			continue
+		}
+
+		for _, currentRoleID := range roleIDsByKey {
+			if currentRoleID != roleID {
+				continue
 			}
+
+			matchingPanels = append(matchingPanels, &struct {
+				Title     string
+				MessageID string
+				RoleCount int
+			}{
+				Title:     panel.Title,
+				MessageID: panel.MessageID,
+				RoleCount: len(panel.Options),
+			})
+			break
 		}
 	}
 
 	if len(matchingPanels) == 0 {
+		description := fmt.Sprintf("ロール <@&%s> を含むパネルが見つかりません。", roleID)
+		if hadReadError {
+			description += "\n一部のパネルを確認できませんでした。"
+		}
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{
 				Embeds: []*discordgo.MessageEmbed{
 					{
 						Title:       "エラー",
-						Description: fmt.Sprintf("ロール <@&%s> を含むパネルが見つかりません。", roleID),
+						Description: description,
 						Color:       config.Colors.Error,
 						Footer: &discordgo.MessageEmbedFooter{
 							Text:    "Requested by " + i.Member.DisplayName(),
@@ -116,7 +129,6 @@ func Remove(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.Interac
 			Description: fmt.Sprintf("%d個のロール", panel.RoleCount),
 		})
 	}
-
 	customID := fmt.Sprintf("rolepanel_remove_%s", roleID)
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{

--- a/src/internal/bot/messageComponent/rolepanel.go
+++ b/src/internal/bot/messageComponent/rolepanel.go
@@ -96,15 +96,19 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 		if shouldHaveRole && !hasRole {
 			// ロールを追加
 			err := s.GuildMemberRoleAdd(i.GuildID, i.Member.User.ID, roleID)
-			if err == nil {
-				addedRoles = append(addedRoles, roleID)
+			if err != nil {
+				fmt.Printf("failed to add role %s to user %s in guild %s: %v\n", roleID, i.Member.User.ID, i.GuildID, err)
+				continue
 			}
+			addedRoles = append(addedRoles, roleID)
 		} else if !shouldHaveRole && hasRole {
 			// ロールを削除
 			err := s.GuildMemberRoleRemove(i.GuildID, i.Member.User.ID, roleID)
-			if err == nil {
-				removedRoles = append(removedRoles, roleID)
+			if err != nil {
+				fmt.Printf("failed to remove role %s from user %s in guild %s: %v\n", roleID, i.Member.User.ID, i.GuildID, err)
+				continue
 			}
+			removedRoles = append(removedRoles, roleID)
 		}
 	}
 

--- a/src/internal/bot/messageComponent/rolepanel.go
+++ b/src/internal/bot/messageComponent/rolepanel.go
@@ -21,6 +21,26 @@ func init() {
 // HandleRolePanelSelect はロールパネルのセレクトメニューを処理します
 func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
+
+	// Guildチェック
+	if i.GuildID == "" {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このコマンドはサーバー内でのみ使用できます。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
 	customID := i.MessageComponentData().CustomID
 	selectedRoleIDs := i.MessageComponentData().Values
 
@@ -38,6 +58,25 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 					{
 						Title:       "エラー",
 						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// GuildID一致チェック
+	if panel.GuildID != i.GuildID {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このパネルは別のサーバーのものです。",
 						Color:       config.Colors.Error,
 						Timestamp:   time.Now().Format(time.RFC3339),
 					},
@@ -217,6 +256,45 @@ func intPtr(i int) *int {
 // HandleRolePanelAdd はロール追加用のパネル選択を処理します
 func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
+
+	// Guildチェック
+	if i.GuildID == "" {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このコマンドはサーバー内でのみ使用できます。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// 権限チェック
+	if i.Member.Permissions&discordgo.PermissionManageRoles == 0 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "この操作には「ロールの管理」権限が必要です。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
 	customID := i.MessageComponentData().CustomID
 	values := i.MessageComponentData().Values
 
@@ -256,6 +334,25 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 					{
 						Title:       "エラー",
 						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// GuildID一致チェック
+	if panel.GuildID != i.GuildID {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このパネルは別のサーバーのものです。",
 						Color:       config.Colors.Error,
 						Timestamp:   time.Now().Format(time.RFC3339),
 					},
@@ -357,6 +454,45 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 // HandleRolePanelDelete はパネル削除用のセレクトを処理します
 func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
+
+	// Guildチェック
+	if i.GuildID == "" {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このコマンドはサーバー内でのみ使用できます。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// 権限チェック
+	if i.Member.Permissions&discordgo.PermissionManageRoles == 0 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "この操作には「ロールの管理」権限が必要です。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
 	values := i.MessageComponentData().Values
 
 	if len(values) == 0 {
@@ -376,6 +512,25 @@ func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *di
 					{
 						Title:       "エラー",
 						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// GuildID一致チェック
+	if panel.GuildID != i.GuildID {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このパネルは別のサーバーのものです。",
 						Color:       config.Colors.Error,
 						Timestamp:   time.Now().Format(time.RFC3339),
 					},
@@ -430,6 +585,45 @@ func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *di
 // HandleRolePanelRemove はロール削除用のパネル選択を処理します
 func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
+
+	// Guildチェック
+	if i.GuildID == "" {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このコマンドはサーバー内でのみ使用できます。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// 権限チェック
+	if i.Member.Permissions&discordgo.PermissionManageRoles == 0 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "この操作には「ロールの管理」権限が必要です。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
 	customID := i.MessageComponentData().CustomID
 	values := i.MessageComponentData().Values
 
@@ -452,6 +646,25 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 					{
 						Title:       "エラー",
 						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// GuildID一致チェック
+	if panel.GuildID != i.GuildID {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このパネルは別のサーバーのものです。",
 						Color:       config.Colors.Error,
 						Timestamp:   time.Now().Format(time.RFC3339),
 					},

--- a/src/internal/bot/messageComponent/rolepanel.go
+++ b/src/internal/bot/messageComponent/rolepanel.go
@@ -1,8 +1,12 @@
 package messageComponent
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 	"unibot/internal"
 	"unibot/internal/model"
@@ -10,6 +14,31 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 )
+
+const (
+	rolePanelOptionValueSeparator = "|"
+	rolePanelOptionKeyBytes       = 8
+	rolePanelPendingAddTTL        = 10 * time.Minute
+)
+
+var errInvalidRolePanelOptionValue = errors.New("invalid rolepanel option value")
+
+type RolePanelPendingAdd struct {
+	UserID      string
+	GuildID     string
+	RoleID      string
+	Label       string
+	Description string
+	Emoji       string
+	ExpiresAt   time.Time
+}
+
+var rolePanelPendingAdds = struct {
+	mu    sync.Mutex
+	items map[string]RolePanelPendingAdd
+}{
+	items: make(map[string]RolePanelPendingAdd),
+}
 
 func init() {
 	RegisterHandler("rolepanel_select_", HandleRolePanelSelect)
@@ -22,7 +51,6 @@ func init() {
 func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
 
-	// Guildチェック
 	if i.GuildID == "" {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -42,12 +70,9 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 	}
 
 	customID := i.MessageComponentData().CustomID
-	selectedRoleIDs := i.MessageComponentData().Values
-
-	// CustomIDからメッセージIDを取得 (rolepanel_select_messageID)
+	selectedValues := i.MessageComponentData().Values
 	messageID := strings.TrimPrefix(customID, "rolepanel_select_")
 
-	// パネルを取得
 	repo := repository.NewRolePanelRepository(ctx.DB)
 	panel, err := repo.GetByMessageID(messageID)
 	if err != nil || panel == nil {
@@ -68,7 +93,6 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// GuildID一致チェック
 	if panel.GuildID != i.GuildID {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -87,22 +111,49 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// パネルに登録されている全ロールIDを取得
-	panelRoleIDs := make(map[string]bool)
-	for _, opt := range panel.Options {
-		panelRoleIDs[opt.RoleID] = true
+	messageRoleIDs, err := RolePanelRoleIDsByOptionKey(i.Message)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルのロール情報の読み取りに失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
 	}
 
-	// 選択されたロールをマップに変換
-	selectedMap := make(map[string]bool)
-	for _, roleID := range selectedRoleIDs {
-		selectedMap[roleID] = true
+	panelRoleIDs := panelRoleIDsByOptionKey(panel, messageRoleIDs)
+	selectedRoleMap := make(map[string]bool)
+	for _, value := range selectedValues {
+		_, roleID, err := DecodeRolePanelOptionValue(value)
+		if err != nil {
+			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseChannelMessageWithSource,
+				Data: &discordgo.InteractionResponseData{
+					Embeds: []*discordgo.MessageEmbed{
+						{
+							Title:       "エラー",
+							Description: "選択されたロール情報の読み取りに失敗しました。",
+							Color:       config.Colors.Error,
+							Timestamp:   time.Now().Format(time.RFC3339),
+						},
+					},
+					Flags: discordgo.MessageFlagsEphemeral,
+				},
+			})
+			return
+		}
+		selectedRoleMap[roleID] = true
 	}
 
-	var addedRoles []string
-	var removedRoles []string
-
-	// ユーザーの現在のロールを確認
 	member, err := s.GuildMember(i.GuildID, i.Member.User.ID)
 	if err != nil {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -127,23 +178,23 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 		currentRoles[roleID] = true
 	}
 
-	// ロールの追加・削除を処理
-	for roleID := range panelRoleIDs {
+	var addedRoles []string
+	var removedRoles []string
+	for _, roleID := range panelRoleIDs {
 		hasRole := currentRoles[roleID]
-		shouldHaveRole := selectedMap[roleID]
+		shouldHaveRole := selectedRoleMap[roleID]
 
 		if shouldHaveRole && !hasRole {
-			// ロールを追加
-			err := s.GuildMemberRoleAdd(i.GuildID, i.Member.User.ID, roleID)
-			if err != nil {
+			if err := s.GuildMemberRoleAdd(i.GuildID, i.Member.User.ID, roleID); err != nil {
 				fmt.Printf("failed to add role %s to user %s in guild %s: %v\n", roleID, i.Member.User.ID, i.GuildID, err)
 				continue
 			}
 			addedRoles = append(addedRoles, roleID)
-		} else if !shouldHaveRole && hasRole {
-			// ロールを削除
-			err := s.GuildMemberRoleRemove(i.GuildID, i.Member.User.ID, roleID)
-			if err != nil {
+			continue
+		}
+
+		if !shouldHaveRole && hasRole {
+			if err := s.GuildMemberRoleRemove(i.GuildID, i.Member.User.ID, roleID); err != nil {
 				fmt.Printf("failed to remove role %s from user %s in guild %s: %v\n", roleID, i.Member.User.ID, i.GuildID, err)
 				continue
 			}
@@ -151,7 +202,6 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 		}
 	}
 
-	// 更新後のユーザーのロール状態を計算
 	newRoles := make(map[string]bool)
 	for roleID := range currentRoles {
 		newRoles[roleID] = true
@@ -163,7 +213,6 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 		delete(newRoles, roleID)
 	}
 
-	// 結果メッセージを作成
 	var description string
 	if len(addedRoles) == 0 && len(removedRoles) == 0 {
 		description = "ロールに変更はありませんでした。"
@@ -185,52 +234,22 @@ func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *di
 		}
 	}
 
-	// 現在のロール状態を表示
 	description += "\n**現在のロール:**\n"
 	hasAnyRole := false
 	for _, opt := range panel.Options {
-		if newRoles[opt.RoleID] {
-			description += fmt.Sprintf("- <@&%s>\n", opt.RoleID)
-			hasAnyRole = true
+		roleID, ok := messageRoleIDs[opt.OptionKey]
+		if !ok || !newRoles[roleID] {
+			continue
 		}
+		description += fmt.Sprintf("- <@&%s>\n", roleID)
+		hasAnyRole = true
 	}
 	if !hasAnyRole {
 		description += "なし\n"
 	}
 
-	// ユーザー専用のセレクトメニューを作成（現在のロールがデフォルト選択）
-	var selectOptions []discordgo.SelectMenuOption
-	for _, opt := range panel.Options {
-		option := discordgo.SelectMenuOption{
-			Label:       opt.Label,
-			Value:       opt.RoleID,
-			Description: opt.Description,
-			Default:     newRoles[opt.RoleID],
-		}
-		if opt.Emoji != "" {
-			option.Emoji = &discordgo.ComponentEmoji{
-				Name: opt.Emoji,
-			}
-		}
-		selectOptions = append(selectOptions, option)
-	}
-
-	var components []discordgo.MessageComponent
-	if len(selectOptions) > 0 {
-		components = []discordgo.MessageComponent{
-			discordgo.ActionsRow{
-				Components: []discordgo.MessageComponent{
-					discordgo.SelectMenu{
-						CustomID:    "rolepanel_select_" + panel.MessageID,
-						Placeholder: "ロールを選択...",
-						MinValues:   intPtr(0),
-						MaxValues:   len(selectOptions),
-						Options:     selectOptions,
-					},
-				},
-			},
-		}
-	}
+	selectOptions := buildPanelSelectOptions(panel, messageRoleIDs, newRoles)
+	components := buildPanelComponents(panel.MessageID, selectOptions)
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -257,7 +276,6 @@ func intPtr(i int) *int {
 func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
 
-	// Guildチェック
 	if i.GuildID == "" {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -276,7 +294,6 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 		return
 	}
 
-	// 権限チェック
 	if i.Member.Permissions&discordgo.PermissionManageRoles == 0 {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -297,34 +314,32 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 
 	customID := i.MessageComponentData().CustomID
 	values := i.MessageComponentData().Values
-
 	if len(values) == 0 {
 		return
 	}
 
 	messageID := values[0]
-
-	// CustomIDからロール情報をデコード (rolepanel_add_roleID|label|description|emoji)
-	parts := strings.TrimPrefix(customID, "rolepanel_add_")
-	data := strings.Split(parts, "|")
-	if len(data) < 2 {
+	token := strings.TrimPrefix(customID, "rolepanel_add_")
+	pendingAdd, ok := ConsumeRolePanelPendingAdd(token, i.Member.User.ID, i.GuildID)
+	if !ok {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "ロール追加の有効期限が切れたか、無効な操作です。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
 		return
 	}
 
-	roleID := data[0]
-	label := data[1]
-	description := ""
-	emoji := ""
-	if len(data) > 2 {
-		description = data[2]
-	}
-	if len(data) > 3 {
-		emoji = data[3]
-	}
-
 	repo := repository.NewRolePanelRepository(ctx.DB)
-
-	// パネルを取得
 	panel, err := repo.GetByMessageID(messageID)
 	if err != nil || panel == nil {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -344,7 +359,6 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 		return
 	}
 
-	// GuildID一致チェック
 	if panel.GuildID != i.GuildID {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -363,7 +377,6 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 		return
 	}
 
-	// オプション数の上限チェック (Discord制限: 25)
 	if len(panel.Options) >= 25 {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -382,9 +395,46 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 		return
 	}
 
-	// 重複チェック
-	for _, opt := range panel.Options {
-		if opt.RoleID == roleID {
+	message, err := s.ChannelMessage(panel.ChannelID, panel.MessageID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルメッセージの取得に失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	messageRoleIDs, err := RolePanelRoleIDsByOptionKey(message)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルのロール情報の読み取りに失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	for _, roleID := range messageRoleIDs {
+		if roleID == pendingAdd.RoleID {
 			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 				Type: discordgo.InteractionResponseUpdateMessage,
 				Data: &discordgo.InteractionResponseData{
@@ -403,17 +453,34 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 		}
 	}
 
-	// オプションを追加
-	option := &model.RolePanelOption{
-		RolePanelID: panel.ID,
-		RoleID:      roleID,
-		Label:       label,
-		Description: description,
-		Emoji:       emoji,
+	optionKey, err := NewRolePanelOptionKey()
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "ロール情報の準備中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
 	}
 
-	err = repo.AddOption(option)
-	if err != nil {
+	option := &model.RolePanelOption{
+		RolePanelID: panel.ID,
+		OptionKey:   optionKey,
+		Label:       pendingAdd.Label,
+		Description: pendingAdd.Description,
+		Emoji:       pendingAdd.Emoji,
+	}
+
+	if err := repo.AddOption(option); err != nil {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{
@@ -431,9 +498,26 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 		return
 	}
 
-	// パネルを再取得してメッセージを更新
 	panel, _ = repo.GetByMessageID(messageID)
-	UpdatePanelMessage(s, panel, config)
+	if err := UpdatePanelMessage(s, panel, config, map[string]string{
+		optionKey: pendingAdd.RoleID,
+	}); err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルメッセージの更新に失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
@@ -441,7 +525,7 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 			Embeds: []*discordgo.MessageEmbed{
 				{
 					Title:       "ロールを追加しました",
-					Description: fmt.Sprintf("ロール <@&%s> を **%s** に追加しました。", roleID, panel.Title),
+					Description: fmt.Sprintf("ロール <@&%s> を **%s** に追加しました。", pendingAdd.RoleID, panel.Title),
 					Color:       config.Colors.Success,
 					Timestamp:   time.Now().Format(time.RFC3339),
 				},
@@ -455,7 +539,6 @@ func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *disco
 func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
 
-	// Guildチェック
 	if i.GuildID == "" {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -474,7 +557,6 @@ func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// 権限チェック
 	if i.Member.Permissions&discordgo.PermissionManageRoles == 0 {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -494,15 +576,12 @@ func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *di
 	}
 
 	values := i.MessageComponentData().Values
-
 	if len(values) == 0 {
 		return
 	}
 
 	messageID := values[0]
 	repo := repository.NewRolePanelRepository(ctx.DB)
-
-	// パネルを取得
 	panel, err := repo.GetByMessageID(messageID)
 	if err != nil || panel == nil {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -522,7 +601,6 @@ func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// GuildID一致チェック
 	if panel.GuildID != i.GuildID {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -542,13 +620,9 @@ func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *di
 	}
 
 	panelTitle := panel.Title
-
-	// メッセージを削除
 	_ = s.ChannelMessageDelete(panel.ChannelID, panel.MessageID)
 
-	// データベースから削除
-	err = repo.DeleteByID(panel.ID)
-	if err != nil {
+	if err := repo.DeleteByID(panel.ID); err != nil {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{
@@ -586,7 +660,6 @@ func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *di
 func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
 	config := ctx.Config
 
-	// Guildチェック
 	if i.GuildID == "" {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -605,7 +678,6 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// 権限チェック
 	if i.Member.Permissions&discordgo.PermissionManageRoles == 0 {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -626,17 +698,13 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 
 	customID := i.MessageComponentData().CustomID
 	values := i.MessageComponentData().Values
-
 	if len(values) == 0 {
 		return
 	}
 
 	messageID := values[0]
 	roleID := strings.TrimPrefix(customID, "rolepanel_remove_")
-
 	repo := repository.NewRolePanelRepository(ctx.DB)
-
-	// パネルを取得
 	panel, err := repo.GetByMessageID(messageID)
 	if err != nil || panel == nil {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
@@ -656,7 +724,6 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// GuildID一致チェック
 	if panel.GuildID != i.GuildID {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
@@ -675,18 +742,53 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// ロールを探す
-	var optionID uint
-	found := false
-	for _, opt := range panel.Options {
-		if opt.RoleID == roleID {
-			optionID = opt.ID
-			found = true
+	message, err := s.ChannelMessage(panel.ChannelID, panel.MessageID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルメッセージの取得に失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	messageRoleIDs, err := RolePanelRoleIDsByOptionKey(message)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルのロール情報の読み取りに失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	var optionKey string
+	for key, currentRoleID := range messageRoleIDs {
+		if currentRoleID == roleID {
+			optionKey = key
 			break
 		}
 	}
 
-	if !found {
+	if optionKey == "" {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{
@@ -704,9 +806,26 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// オプションを削除
-	err = repo.DeleteOptionByID(optionID)
-	if err != nil {
+	option := panelOptionByKey(panel, optionKey)
+	if option == nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このロールの設定が見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	if err := repo.DeleteOptionByID(option.ID); err != nil {
 		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseUpdateMessage,
 			Data: &discordgo.InteractionResponseData{
@@ -724,9 +843,24 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 		return
 	}
 
-	// パネルを再取得してメッセージを更新
 	panel, _ = repo.GetByMessageID(messageID)
-	UpdatePanelMessage(s, panel, config)
+	if err := UpdatePanelMessage(s, panel, config, nil); err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルメッセージの更新に失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
 
 	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
@@ -745,7 +879,28 @@ func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *di
 }
 
 // UpdatePanelMessage はパネルのメッセージを更新します
-func UpdatePanelMessage(s *discordgo.Session, panel *model.RolePanel, config *internal.Config) {
+func UpdatePanelMessage(s *discordgo.Session, panel *model.RolePanel, config *internal.Config, extraRoleIDs map[string]string) error {
+	if panel == nil {
+		return fmt.Errorf("role panel is nil")
+	}
+
+	roleIDsByKey := make(map[string]string)
+	message, err := s.ChannelMessage(panel.ChannelID, panel.MessageID)
+	if err != nil {
+		if len(panel.Options) > 0 && len(extraRoleIDs) == 0 {
+			return err
+		}
+	} else {
+		roleIDsByKey, err = RolePanelRoleIDsByOptionKey(message)
+		if err != nil {
+			return err
+		}
+	}
+
+	for optionKey, roleID := range extraRoleIDs {
+		roleIDsByKey[optionKey] = roleID
+	}
+
 	embed := &discordgo.MessageEmbed{
 		Title:       panel.Title,
 		Description: panel.Description,
@@ -756,42 +911,182 @@ func UpdatePanelMessage(s *discordgo.Session, panel *model.RolePanel, config *in
 		Timestamp: time.Now().Format(time.RFC3339),
 	}
 
-	var selectOptions []discordgo.SelectMenuOption
-	for _, opt := range panel.Options {
-		option := discordgo.SelectMenuOption{
-			Label:       opt.Label,
-			Value:       opt.RoleID,
-			Description: opt.Description,
-		}
-		if opt.Emoji != "" {
-			option.Emoji = &discordgo.ComponentEmoji{
-				Name: opt.Emoji,
-			}
-		}
-		selectOptions = append(selectOptions, option)
-	}
+	selectOptions := buildPanelSelectOptions(panel, roleIDsByKey, nil)
+	components := buildPanelComponents(panel.MessageID, selectOptions)
 
-	var components []discordgo.MessageComponent
-	if len(selectOptions) > 0 {
-		components = []discordgo.MessageComponent{
-			discordgo.ActionsRow{
-				Components: []discordgo.MessageComponent{
-					discordgo.SelectMenu{
-						CustomID:    "rolepanel_select_" + panel.MessageID,
-						Placeholder: "ロールを選択...",
-						MinValues:   intPtr(0),
-						MaxValues:   len(selectOptions),
-						Options:     selectOptions,
-					},
-				},
-			},
-		}
-	}
-
-	_, _ = s.ChannelMessageEditComplex(&discordgo.MessageEdit{
+	_, err = s.ChannelMessageEditComplex(&discordgo.MessageEdit{
 		Channel:    panel.ChannelID,
 		ID:         panel.MessageID,
 		Embeds:     &[]*discordgo.MessageEmbed{embed},
 		Components: &components,
 	})
+	return err
+}
+
+func buildPanelComponents(messageID string, selectOptions []discordgo.SelectMenuOption) []discordgo.MessageComponent {
+	components := []discordgo.MessageComponent{}
+	if len(selectOptions) == 0 {
+		return components
+	}
+
+	return []discordgo.MessageComponent{
+		discordgo.ActionsRow{
+			Components: []discordgo.MessageComponent{
+				discordgo.SelectMenu{
+					CustomID:    "rolepanel_select_" + messageID,
+					Placeholder: "ロールを選択...",
+					MinValues:   intPtr(0),
+					MaxValues:   len(selectOptions),
+					Options:     selectOptions,
+				},
+			},
+		},
+	}
+}
+
+func buildPanelSelectOptions(panel *model.RolePanel, roleIDsByKey map[string]string, defaultRoles map[string]bool) []discordgo.SelectMenuOption {
+	var selectOptions []discordgo.SelectMenuOption
+	for _, opt := range panel.Options {
+		roleID, ok := roleIDsByKey[opt.OptionKey]
+		if !ok {
+			continue
+		}
+
+		option := discordgo.SelectMenuOption{
+			Label:       opt.Label,
+			Value:       EncodeRolePanelOptionValue(opt.OptionKey, roleID),
+			Description: opt.Description,
+			Default:     defaultRoles != nil && defaultRoles[roleID],
+		}
+		if opt.Emoji != "" {
+			option.Emoji = &discordgo.ComponentEmoji{Name: opt.Emoji}
+		}
+		selectOptions = append(selectOptions, option)
+	}
+	return selectOptions
+}
+
+func panelRoleIDsByOptionKey(panel *model.RolePanel, roleIDsByKey map[string]string) []string {
+	var roleIDs []string
+	for _, opt := range panel.Options {
+		roleID, ok := roleIDsByKey[opt.OptionKey]
+		if ok {
+			roleIDs = append(roleIDs, roleID)
+		}
+	}
+	return roleIDs
+}
+
+func panelOptionByKey(panel *model.RolePanel, optionKey string) *model.RolePanelOption {
+	for _, opt := range panel.Options {
+		if opt.OptionKey == optionKey {
+			return opt
+		}
+	}
+	return nil
+}
+
+func NewRolePanelOptionKey() (string, error) {
+	buf := make([]byte, rolePanelOptionKeyBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func EncodeRolePanelOptionValue(optionKey, roleID string) string {
+	return optionKey + rolePanelOptionValueSeparator + roleID
+}
+
+func DecodeRolePanelOptionValue(value string) (string, string, error) {
+	parts := strings.SplitN(value, rolePanelOptionValueSeparator, 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("%w: %q", errInvalidRolePanelOptionValue, value)
+	}
+	return parts[0], parts[1], nil
+}
+
+func RolePanelRoleIDsByOptionKey(message *discordgo.Message) (map[string]string, error) {
+	roleIDs := make(map[string]string)
+	if message == nil {
+		return roleIDs, nil
+	}
+
+	for _, component := range message.Components {
+		row, ok := component.(discordgo.ActionsRow)
+		if !ok {
+			continue
+		}
+
+		for _, child := range row.Components {
+			menu, ok := child.(discordgo.SelectMenu)
+			if !ok {
+				continue
+			}
+
+			for _, option := range menu.Options {
+				optionKey, roleID, err := DecodeRolePanelOptionValue(option.Value)
+				if err != nil {
+					return nil, err
+				}
+				roleIDs[optionKey] = roleID
+			}
+		}
+	}
+
+	return roleIDs, nil
+}
+
+func SaveRolePanelPendingAdd(add RolePanelPendingAdd) (string, error) {
+	token, err := newRolePanelPendingAddToken()
+	if err != nil {
+		return "", err
+	}
+
+	add.ExpiresAt = time.Now().Add(rolePanelPendingAddTTL)
+
+	rolePanelPendingAdds.mu.Lock()
+	defer rolePanelPendingAdds.mu.Unlock()
+
+	deleteExpiredRolePanelPendingAddsLocked(time.Now())
+	rolePanelPendingAdds.items[token] = add
+
+	return token, nil
+}
+
+func ConsumeRolePanelPendingAdd(token, userID, guildID string) (RolePanelPendingAdd, bool) {
+	now := time.Now()
+
+	rolePanelPendingAdds.mu.Lock()
+	defer rolePanelPendingAdds.mu.Unlock()
+
+	deleteExpiredRolePanelPendingAddsLocked(now)
+
+	add, ok := rolePanelPendingAdds.items[token]
+	if !ok {
+		return RolePanelPendingAdd{}, false
+	}
+	if add.UserID != userID || add.GuildID != guildID || now.After(add.ExpiresAt) {
+		delete(rolePanelPendingAdds.items, token)
+		return RolePanelPendingAdd{}, false
+	}
+
+	delete(rolePanelPendingAdds.items, token)
+	return add, true
+}
+
+func deleteExpiredRolePanelPendingAddsLocked(now time.Time) {
+	for token, add := range rolePanelPendingAdds.items {
+		if now.After(add.ExpiresAt) {
+			delete(rolePanelPendingAdds.items, token)
+		}
+	}
+}
+
+func newRolePanelPendingAddToken() (string, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
 }

--- a/src/internal/bot/messageComponent/rolepanel.go
+++ b/src/internal/bot/messageComponent/rolepanel.go
@@ -1,0 +1,580 @@
+package messageComponent
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	"unibot/internal"
+	"unibot/internal/model"
+	"unibot/internal/repository"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+func init() {
+	RegisterHandler("rolepanel_select_", HandleRolePanelSelect)
+	RegisterHandler("rolepanel_add_", HandleRolePanelAdd)
+	RegisterHandler("rolepanel_delete", HandleRolePanelDelete)
+	RegisterHandler("rolepanel_remove_", HandleRolePanelRemove)
+}
+
+// HandleRolePanelSelect はロールパネルのセレクトメニューを処理します
+func HandleRolePanelSelect(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	customID := i.MessageComponentData().CustomID
+	selectedRoleIDs := i.MessageComponentData().Values
+
+	// CustomIDからメッセージIDを取得 (rolepanel_select_messageID)
+	messageID := strings.TrimPrefix(customID, "rolepanel_select_")
+
+	// パネルを取得
+	repo := repository.NewRolePanelRepository(ctx.DB)
+	panel, err := repo.GetByMessageID(messageID)
+	if err != nil || panel == nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	// パネルに登録されている全ロールIDを取得
+	panelRoleIDs := make(map[string]bool)
+	for _, opt := range panel.Options {
+		panelRoleIDs[opt.RoleID] = true
+	}
+
+	// 選択されたロールをマップに変換
+	selectedMap := make(map[string]bool)
+	for _, roleID := range selectedRoleIDs {
+		selectedMap[roleID] = true
+	}
+
+	var addedRoles []string
+	var removedRoles []string
+
+	// ユーザーの現在のロールを確認
+	member, err := s.GuildMember(i.GuildID, i.Member.User.ID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "メンバー情報の取得に失敗しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Flags: discordgo.MessageFlagsEphemeral,
+			},
+		})
+		return
+	}
+
+	currentRoles := make(map[string]bool)
+	for _, roleID := range member.Roles {
+		currentRoles[roleID] = true
+	}
+
+	// ロールの追加・削除を処理
+	for roleID := range panelRoleIDs {
+		hasRole := currentRoles[roleID]
+		shouldHaveRole := selectedMap[roleID]
+
+		if shouldHaveRole && !hasRole {
+			// ロールを追加
+			err := s.GuildMemberRoleAdd(i.GuildID, i.Member.User.ID, roleID)
+			if err == nil {
+				addedRoles = append(addedRoles, roleID)
+			}
+		} else if !shouldHaveRole && hasRole {
+			// ロールを削除
+			err := s.GuildMemberRoleRemove(i.GuildID, i.Member.User.ID, roleID)
+			if err == nil {
+				removedRoles = append(removedRoles, roleID)
+			}
+		}
+	}
+
+	// 更新後のユーザーのロール状態を計算
+	newRoles := make(map[string]bool)
+	for roleID := range currentRoles {
+		newRoles[roleID] = true
+	}
+	for _, roleID := range addedRoles {
+		newRoles[roleID] = true
+	}
+	for _, roleID := range removedRoles {
+		delete(newRoles, roleID)
+	}
+
+	// 結果メッセージを作成
+	var description string
+	if len(addedRoles) == 0 && len(removedRoles) == 0 {
+		description = "ロールに変更はありませんでした。"
+	} else {
+		if len(addedRoles) > 0 {
+			description += "**追加されたロール:**\n"
+			for _, roleID := range addedRoles {
+				description += fmt.Sprintf("- <@&%s>\n", roleID)
+			}
+		}
+		if len(removedRoles) > 0 {
+			if len(addedRoles) > 0 {
+				description += "\n"
+			}
+			description += "**削除されたロール:**\n"
+			for _, roleID := range removedRoles {
+				description += fmt.Sprintf("- <@&%s>\n", roleID)
+			}
+		}
+	}
+
+	// 現在のロール状態を表示
+	description += "\n**現在のロール:**\n"
+	hasAnyRole := false
+	for _, opt := range panel.Options {
+		if newRoles[opt.RoleID] {
+			description += fmt.Sprintf("- <@&%s>\n", opt.RoleID)
+			hasAnyRole = true
+		}
+	}
+	if !hasAnyRole {
+		description += "なし\n"
+	}
+
+	// ユーザー専用のセレクトメニューを作成（現在のロールがデフォルト選択）
+	var selectOptions []discordgo.SelectMenuOption
+	for _, opt := range panel.Options {
+		option := discordgo.SelectMenuOption{
+			Label:       opt.Label,
+			Value:       opt.RoleID,
+			Description: opt.Description,
+			Default:     newRoles[opt.RoleID],
+		}
+		if opt.Emoji != "" {
+			option.Emoji = &discordgo.ComponentEmoji{
+				Name: opt.Emoji,
+			}
+		}
+		selectOptions = append(selectOptions, option)
+	}
+
+	var components []discordgo.MessageComponent
+	if len(selectOptions) > 0 {
+		components = []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.SelectMenu{
+						CustomID:    "rolepanel_select_" + panel.MessageID,
+						Placeholder: "ロールを選択...",
+						MinValues:   intPtr(0),
+						MaxValues:   len(selectOptions),
+						Options:     selectOptions,
+					},
+				},
+			},
+		}
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "ロールを更新しました",
+					Description: description,
+					Color:       config.Colors.Success,
+					Timestamp:   time.Now().Format(time.RFC3339),
+				},
+			},
+			Components: components,
+			Flags:      discordgo.MessageFlagsEphemeral,
+		},
+	})
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
+// HandleRolePanelAdd はロール追加用のパネル選択を処理します
+func HandleRolePanelAdd(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	customID := i.MessageComponentData().CustomID
+	values := i.MessageComponentData().Values
+
+	if len(values) == 0 {
+		return
+	}
+
+	messageID := values[0]
+
+	// CustomIDからロール情報をデコード (rolepanel_add_roleID|label|description|emoji)
+	parts := strings.TrimPrefix(customID, "rolepanel_add_")
+	data := strings.Split(parts, "|")
+	if len(data) < 2 {
+		return
+	}
+
+	roleID := data[0]
+	label := data[1]
+	description := ""
+	emoji := ""
+	if len(data) > 2 {
+		description = data[2]
+	}
+	if len(data) > 3 {
+		emoji = data[3]
+	}
+
+	repo := repository.NewRolePanelRepository(ctx.DB)
+
+	// パネルを取得
+	panel, err := repo.GetByMessageID(messageID)
+	if err != nil || panel == nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// オプション数の上限チェック (Discord制限: 25)
+	if len(panel.Options) >= 25 {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このパネルには最大25個までのロールしか追加できません。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// 重複チェック
+	for _, opt := range panel.Options {
+		if opt.RoleID == roleID {
+			_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseUpdateMessage,
+				Data: &discordgo.InteractionResponseData{
+					Embeds: []*discordgo.MessageEmbed{
+						{
+							Title:       "エラー",
+							Description: "このロールはすでにパネルに追加されています。",
+							Color:       config.Colors.Error,
+							Timestamp:   time.Now().Format(time.RFC3339),
+						},
+					},
+					Components: []discordgo.MessageComponent{},
+				},
+			})
+			return
+		}
+	}
+
+	// オプションを追加
+	option := &model.RolePanelOption{
+		RolePanelID: panel.ID,
+		RoleID:      roleID,
+		Label:       label,
+		Description: description,
+		Emoji:       emoji,
+	}
+
+	err = repo.AddOption(option)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "ロールの追加中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// パネルを再取得してメッセージを更新
+	panel, _ = repo.GetByMessageID(messageID)
+	UpdatePanelMessage(s, panel, config)
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "ロールを追加しました",
+					Description: fmt.Sprintf("ロール <@&%s> を **%s** に追加しました。", roleID, panel.Title),
+					Color:       config.Colors.Success,
+					Timestamp:   time.Now().Format(time.RFC3339),
+				},
+			},
+			Components: []discordgo.MessageComponent{},
+		},
+	})
+}
+
+// HandleRolePanelDelete はパネル削除用のセレクトを処理します
+func HandleRolePanelDelete(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	values := i.MessageComponentData().Values
+
+	if len(values) == 0 {
+		return
+	}
+
+	messageID := values[0]
+	repo := repository.NewRolePanelRepository(ctx.DB)
+
+	// パネルを取得
+	panel, err := repo.GetByMessageID(messageID)
+	if err != nil || panel == nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	panelTitle := panel.Title
+
+	// メッセージを削除
+	_ = s.ChannelMessageDelete(panel.ChannelID, panel.MessageID)
+
+	// データベースから削除
+	err = repo.DeleteByID(panel.ID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルの削除中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "ロールパネルを削除しました",
+					Description: fmt.Sprintf("**%s** を削除しました。", panelTitle),
+					Color:       config.Colors.Success,
+					Timestamp:   time.Now().Format(time.RFC3339),
+				},
+			},
+			Components: []discordgo.MessageComponent{},
+		},
+	})
+}
+
+// HandleRolePanelRemove はロール削除用のパネル選択を処理します
+func HandleRolePanelRemove(ctx *internal.BotContext, s *discordgo.Session, i *discordgo.InteractionCreate) {
+	config := ctx.Config
+	customID := i.MessageComponentData().CustomID
+	values := i.MessageComponentData().Values
+
+	if len(values) == 0 {
+		return
+	}
+
+	messageID := values[0]
+	roleID := strings.TrimPrefix(customID, "rolepanel_remove_")
+
+	repo := repository.NewRolePanelRepository(ctx.DB)
+
+	// パネルを取得
+	panel, err := repo.GetByMessageID(messageID)
+	if err != nil || panel == nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "パネルが見つかりませんでした。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// ロールを探す
+	var optionID uint
+	found := false
+	for _, opt := range panel.Options {
+		if opt.RoleID == roleID {
+			optionID = opt.ID
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "このロールはパネルに追加されていません。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// オプションを削除
+	err = repo.DeleteOptionByID(optionID)
+	if err != nil {
+		_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Embeds: []*discordgo.MessageEmbed{
+					{
+						Title:       "エラー",
+						Description: "ロールの削除中にエラーが発生しました。",
+						Color:       config.Colors.Error,
+						Timestamp:   time.Now().Format(time.RFC3339),
+					},
+				},
+				Components: []discordgo.MessageComponent{},
+			},
+		})
+		return
+	}
+
+	// パネルを再取得してメッセージを更新
+	panel, _ = repo.GetByMessageID(messageID)
+	UpdatePanelMessage(s, panel, config)
+
+	_ = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Embeds: []*discordgo.MessageEmbed{
+				{
+					Title:       "ロールを削除しました",
+					Description: fmt.Sprintf("ロール <@&%s> を **%s** から削除しました。", roleID, panel.Title),
+					Color:       config.Colors.Success,
+					Timestamp:   time.Now().Format(time.RFC3339),
+				},
+			},
+			Components: []discordgo.MessageComponent{},
+		},
+	})
+}
+
+// UpdatePanelMessage はパネルのメッセージを更新します
+func UpdatePanelMessage(s *discordgo.Session, panel *model.RolePanel, config *internal.Config) {
+	embed := &discordgo.MessageEmbed{
+		Title:       panel.Title,
+		Description: panel.Description,
+		Color:       config.Colors.Primary,
+		Footer: &discordgo.MessageEmbedFooter{
+			Text: "ロールを選択してください",
+		},
+		Timestamp: time.Now().Format(time.RFC3339),
+	}
+
+	var selectOptions []discordgo.SelectMenuOption
+	for _, opt := range panel.Options {
+		option := discordgo.SelectMenuOption{
+			Label:       opt.Label,
+			Value:       opt.RoleID,
+			Description: opt.Description,
+		}
+		if opt.Emoji != "" {
+			option.Emoji = &discordgo.ComponentEmoji{
+				Name: opt.Emoji,
+			}
+		}
+		selectOptions = append(selectOptions, option)
+	}
+
+	var components []discordgo.MessageComponent
+	if len(selectOptions) > 0 {
+		components = []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.SelectMenu{
+						CustomID:    "rolepanel_select_" + panel.MessageID,
+						Placeholder: "ロールを選択...",
+						MinValues:   intPtr(0),
+						MaxValues:   len(selectOptions),
+						Options:     selectOptions,
+					},
+				},
+			},
+		}
+	}
+
+	_, _ = s.ChannelMessageEditComplex(&discordgo.MessageEdit{
+		Channel:    panel.ChannelID,
+		ID:         panel.MessageID,
+		Embeds:     &[]*discordgo.MessageEmbed{embed},
+		Components: &components,
+	})
+}

--- a/src/internal/db/db.go
+++ b/src/internal/db/db.go
@@ -39,5 +39,8 @@ func SetupDB(db *gorm.DB) error {
 	if migrator.HasColumn(&model.TTSPersonalSetting{}, "speed_scale") {
 		migrator.DropColumn(&model.TTSPersonalSetting{}, "speed_scale")
 	}
+	if migrator.HasColumn(&model.RolePanelOption{}, "role_id") {
+		migrator.DropColumn(&model.RolePanelOption{}, "role_id")
+	}
 	return err
 }

--- a/src/internal/db/db.go
+++ b/src/internal/db/db.go
@@ -26,6 +26,8 @@ func SetupDB(db *gorm.DB) error {
 		&model.TTSConnection{},
 		&model.TTSPersonalSetting{},
 		&model.TTSDictionary{},
+		&model.RolePanel{},
+		&model.RolePanelOption{},
 	)
 	return err
 }

--- a/src/internal/model/rolepanel.go
+++ b/src/internal/model/rolepanel.go
@@ -4,12 +4,12 @@ import "time"
 
 // RolePanel セレクトメニュー式ロールパネルのモデル
 type RolePanel struct {
-	ID          uint              `gorm:"primaryKey;autoIncrement"`
-	GuildID     string            `gorm:"size:255;not null;index"`
-	ChannelID   string            `gorm:"size:255;not null"`
-	MessageID   string            `gorm:"size:255;not null;uniqueIndex"`
-	Title       string            `gorm:"size:255;not null"`
-	Description string            `gorm:"size:1000"`
+	ID          uint               `gorm:"primaryKey;autoIncrement"`
+	GuildID     string             `gorm:"size:255;not null;index"`
+	ChannelID   string             `gorm:"size:255;not null"`
+	MessageID   string             `gorm:"size:255;not null;uniqueIndex"`
+	Title       string             `gorm:"size:255;not null"`
+	Description string             `gorm:"size:1000"`
 	Options     []*RolePanelOption `gorm:"foreignKey:RolePanelID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	CreatedAt   time.Time
 	UpdatedAt   time.Time
@@ -19,7 +19,7 @@ type RolePanel struct {
 type RolePanelOption struct {
 	ID          uint   `gorm:"primaryKey;autoIncrement"`
 	RolePanelID uint   `gorm:"not null;index"`
-	RoleID      string `gorm:"size:255;not null"`
+	OptionKey   string `gorm:"size:64;not null;uniqueIndex"`
 	Label       string `gorm:"size:100;not null"`
 	Description string `gorm:"size:100"`
 	Emoji       string `gorm:"size:255"`

--- a/src/internal/model/rolepanel.go
+++ b/src/internal/model/rolepanel.go
@@ -1,0 +1,28 @@
+package model
+
+import "time"
+
+// RolePanel セレクトメニュー式ロールパネルのモデル
+type RolePanel struct {
+	ID          uint              `gorm:"primaryKey;autoIncrement"`
+	GuildID     string            `gorm:"size:255;not null;index"`
+	ChannelID   string            `gorm:"size:255;not null"`
+	MessageID   string            `gorm:"size:255;not null;uniqueIndex"`
+	Title       string            `gorm:"size:255;not null"`
+	Description string            `gorm:"size:1000"`
+	Options     []*RolePanelOption `gorm:"foreignKey:RolePanelID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}
+
+// RolePanelOption ロールパネルの選択肢
+type RolePanelOption struct {
+	ID          uint   `gorm:"primaryKey;autoIncrement"`
+	RolePanelID uint   `gorm:"not null;index"`
+	RoleID      string `gorm:"size:255;not null"`
+	Label       string `gorm:"size:100;not null"`
+	Description string `gorm:"size:100"`
+	Emoji       string `gorm:"size:255"`
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/src/internal/repository/rolepanel.go
+++ b/src/internal/repository/rolepanel.go
@@ -1,0 +1,128 @@
+package repository
+
+import (
+	"errors"
+
+	"gorm.io/gorm"
+
+	"unibot/internal/model"
+)
+
+type RolePanelRepository struct {
+	db *gorm.DB
+}
+
+// 新しいRolePanelリポジトリを作成する
+func NewRolePanelRepository(db *gorm.DB) *RolePanelRepository {
+	return &RolePanelRepository{db: db}
+}
+
+/* ---------------------- CRUD Methods ------------------ */
+
+// ロールパネルを作成する関数
+func (r *RolePanelRepository) Create(panel *model.RolePanel) error {
+	return r.db.Create(panel).Error
+}
+
+// ロールパネルをIDで取得する関数
+func (r *RolePanelRepository) GetByID(id uint) (*model.RolePanel, error) {
+	var panel model.RolePanel
+	err := r.db.Preload("Options").First(&panel, id).Error
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return &panel, err
+}
+
+// ロールパネルをメッセージIDで取得する関数
+func (r *RolePanelRepository) GetByMessageID(messageID string) (*model.RolePanel, error) {
+	var panel model.RolePanel
+	err := r.db.Preload("Options").First(&panel, "message_id = ?", messageID).Error
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return &panel, err
+}
+
+// ロールパネルをギルドIDで全て取得する関数
+func (r *RolePanelRepository) ListByGuild(guildID string) ([]*model.RolePanel, error) {
+	var panels []*model.RolePanel
+	err := r.db.Preload("Options").Where("guild_id = ?", guildID).Order("created_at ASC").Find(&panels).Error
+	return panels, err
+}
+
+// ロールパネルをチャンネルIDで全て取得する関数
+func (r *RolePanelRepository) ListByChannel(channelID string) ([]*model.RolePanel, error) {
+	var panels []*model.RolePanel
+	err := r.db.Preload("Options").Where("channel_id = ?", channelID).Order("created_at ASC").Find(&panels).Error
+	return panels, err
+}
+
+// 全てのロールパネルを取得する関数
+func (r *RolePanelRepository) List() ([]*model.RolePanel, error) {
+	var panels []*model.RolePanel
+	err := r.db.Preload("Options").Find(&panels).Error
+	return panels, err
+}
+
+// ロールパネルを更新する関数
+func (r *RolePanelRepository) Update(panel *model.RolePanel) error {
+	return r.db.Save(panel).Error
+}
+
+// ロールパネルをIDで削除する関数
+func (r *RolePanelRepository) DeleteByID(id uint) error {
+	return r.db.Delete(&model.RolePanel{}, id).Error
+}
+
+// ロールパネルをメッセージIDで削除する関数
+func (r *RolePanelRepository) DeleteByMessageID(messageID string) error {
+	return r.db.Delete(&model.RolePanel{}, "message_id = ?", messageID).Error
+}
+
+// ロールパネルをギルドIDで削除する関数
+func (r *RolePanelRepository) DeleteByGuild(guildID string) error {
+	return r.db.Delete(&model.RolePanel{}, "guild_id = ?", guildID).Error
+}
+
+/* ---------------------- Option Methods ------------------ */
+
+// ロールパネルにオプションを追加する関数
+func (r *RolePanelRepository) AddOption(option *model.RolePanelOption) error {
+	return r.db.Create(option).Error
+}
+
+// オプションをIDで取得する関数
+func (r *RolePanelRepository) GetOptionByID(id uint) (*model.RolePanelOption, error) {
+	var option model.RolePanelOption
+	err := r.db.First(&option, id).Error
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	return &option, err
+}
+
+// オプションをロールパネルIDで取得する関数
+func (r *RolePanelRepository) ListOptionsByPanelID(panelID uint) ([]*model.RolePanelOption, error) {
+	var options []*model.RolePanelOption
+	err := r.db.Where("role_panel_id = ?", panelID).Order("created_at ASC").Find(&options).Error
+	return options, err
+}
+
+// オプションを更新する関数
+func (r *RolePanelRepository) UpdateOption(option *model.RolePanelOption) error {
+	return r.db.Save(option).Error
+}
+
+// オプションをIDで削除する関数
+func (r *RolePanelRepository) DeleteOptionByID(id uint) error {
+	return r.db.Delete(&model.RolePanelOption{}, id).Error
+}
+
+// オプションをロールパネルIDで全て削除する関数
+func (r *RolePanelRepository) DeleteOptionsByPanelID(panelID uint) error {
+	return r.db.Delete(&model.RolePanelOption{}, "role_panel_id = ?", panelID).Error
+}


### PR DESCRIPTION
This pull request introduces a new "role panel" feature for server management in the Discord bot, allowing admins to create, list, add roles to, remove roles from, and delete role panels via the `/rolepanel` command. It adds the necessary command registration, handler logic, database models, and subcommand implementations to support interactive role management through Discord's UI.

The most important changes are:

**Role Panel Feature Implementation:**

* Added a new `rolepanel` command under server management, with subcommands for creating, deleting, adding, removing, and listing role panels. This includes command registration in `commands.go` and handler mapping in `registry.go`. [[1]](diffhunk://#diff-f5dd124ea965cbd9ff3fb58587ad36ee093643511d9ed343565ed739cfd99344R6) [[2]](diffhunk://#diff-f5dd124ea965cbd9ff3fb58587ad36ee093643511d9ed343565ed739cfd99344R16) [[3]](diffhunk://#diff-6178623848dd629f6ee9ce3ce1aa3c77bbacc7c1a14faece999bf4cbc4657e89R7) [[4]](diffhunk://#diff-6178623848dd629f6ee9ce3ce1aa3c77bbacc7c1a14faece999bf4cbc4657e89R17) [[5]](diffhunk://#diff-90adef331b8087bb8048b9f1da2e5c6d2197e1408325771da9a6ea9e9d83bbfdR1-R65)
* Implemented subcommand logic in separate files: `create.go` for panel creation, `delete.go` for deletion, `add.go` for adding roles, `remove.go` for removing roles, and `list.go` for listing all panels in a server. Each subcommand provides user feedback and interactive selection via Discord embeds and select menus. [[1]](diffhunk://#diff-0a6f07821c99cf22603ef5d17b6cb86b425ba40e4bee3fe2416e8255e801f8d2R1-R143) [[2]](diffhunk://#diff-c2ee53db3780f5f470871e82cdd2e5bb790af348524163178e9956efbf5e6b18R1-R109) [[3]](diffhunk://#diff-c5c5ff082fe5af32b2df499067b0ddeb7b5f81ea929aa3f71d81ba8308d4056cR1-R154) [[4]](diffhunk://#diff-dbe0af0c72765e330b0816408fbebd46c68a79d29cfa29d5868115a26a9a8bd6R1-R151) [[5]](diffhunk://#diff-6817ba8d982e66c10d431f82e0ed52244b57e29128a9336429927b93497b1a42R1-R108)

**Database Model and Migration:**

* Added new GORM models `RolePanel` and `RolePanelOption` to represent panels and their selectable roles, and updated the database setup to auto-migrate these models. [[1]](diffhunk://#diff-5fe919d8bff0551321f91927c64172157656c7279ddf4b3159658436cc8e0668R1-R28) [[2]](diffhunk://#diff-32df012bdfa72f47d48a60611104160332217594da671269312675d0aabd7d3eR29-R30)

These changes enable server admins to manage self-assignable roles through a user-friendly panel system, improving the bot's role management capabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ロールパネルコマンドを追加しました。サーバーでロール割り当てを管理するための新しいUIが利用できるようになります。ロールパネルの作成、削除、ロールの追加・削除、一覧表示が可能です。

* **Chores**
  * 開発環境設定の更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->